### PR TITLE
Simplify RDM filename to match the NWB filename convention

### DIFF
--- a/fingers_rsa/rdm_utils.py
+++ b/fingers_rsa/rdm_utils.py
@@ -9,13 +9,7 @@ def filename(cfg: DictConfig) -> str:
     :param cfg: Hydra config object, including task info
     :return: filename for RDM
     """
-    return (
-        "rdm_{task}_{subject}_arr{array}{neurons}_{distance_metric}_{time_window}"
-    ).format(
-        task=cfg.task.name,
+    return ("sub-{subject}_ses-{session}_rdm").format(
         subject=cfg.array.subject,
-        array=cfg.array.index,
-        neurons=(("_" + cfg.neurons.name) if ("neurons" in cfg) else ""),
-        distance_metric=cfg.metrics.distance,
-        time_window=[cfg.window.start, cfg.window.start + cfg.window.length],
+        session=cfg.session,
     )


### PR DESCRIPTION
May want to add more naming-components in the future.