### PR TITLE
Revert "Upgrade rsatoolbox to newer version to pull in fix for fitter.py fit_regress_nn"

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -251,7 +251,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "dandi"
-version = "0.46.3"
+version = "0.46.2"
 description = "Command line client for interaction with DANDI archive elements"
 category = "main"
 optional = false
@@ -271,7 +271,7 @@ interleave = ">=0.1,<1.0"
 joblib = "*"
 keyring = "!=23.9.0"
 "keyrings.alt" = "*"
-nwbinspector = ">=0.4.12"
+nwbinspector = ">=0.3.8"
 packaging = "*"
 pycryptodomex = "*"
 pydantic = ">=1.9.0"
@@ -336,8 +336,8 @@ wmi = ["wmi (>=1.5.1,<2.0.0)"]
 
 [[package]]
 name = "email-validator"
-version = "1.3.0"
-description = "A robust email address syntax and deliverability validation library."
+version = "1.2.1"
+description = "A robust email syntax and deliverability validation library."
 category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
@@ -406,7 +406,7 @@ pyflakes = ">=2.5.0,<2.6.0"
 
 [[package]]
 name = "fonttools"
-version = "4.37.3"
+version = "4.37.2"
 description = "Tools to manipulate font files"
 category = "main"
 optional = false
@@ -464,7 +464,7 @@ numpy = ">=1.14.5"
 
 [[package]]
 name = "hdmf"
-version = "3.4.5"
+version = "3.4.3"
 description = "A package for standardizing hierarchical object data"
 category = "main"
 optional = false
@@ -480,7 +480,7 @@ scipy = ">=1.1,<2"
 
 [[package]]
 name = "humanize"
-version = "4.4.0"
+version = "4.3.0"
 description = "Python humanize utilities"
 category = "main"
 optional = false
@@ -548,7 +548,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "imageio"
-version = "2.22.0"
+version = "2.21.3"
 description = "Library for reading and writing a wide range of image, video, scientific, and volumetric data formats."
 category = "main"
 optional = false
@@ -725,7 +725,7 @@ format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-
 
 [[package]]
 name = "keyring"
-version = "23.9.3"
+version = "23.9.1"
 description = "Store and access your passwords safely."
 category = "main"
 optional = false
@@ -914,7 +914,7 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pandas"
-version = "1.5.0"
+version = "1.4.4"
 description = "Powerful data structures for data analysis, time series, and statistics"
 category = "main"
 optional = false
@@ -922,14 +922,16 @@ python-versions = ">=3.8"
 
 [package.dependencies]
 numpy = [
+    {version = ">=1.18.5", markers = "platform_machine != \"aarch64\" and platform_machine != \"arm64\" and python_version < \"3.10\""},
+    {version = ">=1.19.2", markers = "platform_machine == \"aarch64\" and python_version < \"3.10\""},
+    {version = ">=1.20.0", markers = "platform_machine == \"arm64\" and python_version < \"3.10\""},
     {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
-    {version = ">=1.20.3", markers = "python_version < \"3.10\""},
 ]
 python-dateutil = ">=2.8.1"
 pytz = ">=2020.1"
 
 [package.extras]
-test = ["pytest-xdist (>=1.31)", "pytest (>=6.0)", "hypothesis (>=5.5.3)"]
+test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
 
 [[package]]
 name = "parso"
@@ -1262,7 +1264,6 @@ description = "Representational Similarity Analysis (RSA) in Python"
 category = "main"
 optional = false
 python-versions = "*"
-develop = false
 
 [package.dependencies]
 coverage = "*"
@@ -1276,12 +1277,6 @@ scikit-image = "*"
 scikit-learn = "*"
 scipy = "*"
 tqdm = "*"
-
-[package.source]
-type = "git"
-url = "https://github.com/rsagroup/rsatoolbox.git"
-reference = "a0630f054d11dae403ade8745751ac8f7b36e070"
-resolved_reference = "a0630f054d11dae403ade8745751ac8f7b36e070"
 
 [[package]]
 name = "ruamel.yaml"
@@ -1448,7 +1443,7 @@ docs = ["sphinx", "nbconvert", "jupyter-client", "ipykernel", "matplotlib", "nbf
 
 [[package]]
 name = "tenacity"
-version = "8.1.0"
+version = "8.0.1"
 description = "Retry code until it succeeds"
 category = "main"
 optional = false
@@ -1644,7 +1639,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "779324f12a4ab5aabda59ca3c1e641d5c7181c4604d80103f01b703ca69521d4"
+content-hash = "3654d401ea0e51b233c690ad9235a019360b29481c2f68724b78f67e81f10d59"
 
 [metadata.files]
 antlr4-python3-runtime = []
@@ -1987,7 +1982,10 @@ statsmodels = [
     {file = "statsmodels-0.13.2-cp39-cp39-win_amd64.whl", hash = "sha256:39daab5a8a9332c8ea83d6464d065080c9ba65f236daf6a64aa18f64ef776fad"},
     {file = "statsmodels-0.13.2.tar.gz", hash = "sha256:77dc292c9939c036a476f1770f9d08976b05437daa229928da73231147cde7d4"},
 ]
-tenacity = []
+tenacity = [
+    {file = "tenacity-8.0.1-py3-none-any.whl", hash = "sha256:f78f4ea81b0fabc06728c11dc2a8c01277bfc5181b321a4770471902e3eb844a"},
+    {file = "tenacity-8.0.1.tar.gz", hash = "sha256:43242a20e3e73291a28bcbcacfd6e000b02d3857a9a9fff56b297a27afdc932f"},
+]
 threadpoolctl = [
     {file = "threadpoolctl-3.1.0-py3-none-any.whl", hash = "sha256:8b99adda265feb6773280df41eece7b2e6561b772d21ffd52e372f999024907b"},
     {file = "threadpoolctl-3.1.0.tar.gz", hash = "sha256:a335baacfaa4400ae1f0d8e3a58d6674d2f8828e3716bb2802c44955ad391380"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ pandas = "^1.2"
 numpy = "^1.13"
 xarray = "^2022.3"
 prince = {git = "https://github.com/MaxHalford/prince.git", rev="c18eff92efbac57e4cd3657a6999cee8d1fcb906"}
-rsatoolbox = {git = "https://github.com/rsagroup/rsatoolbox.git", rev="a0630f054d11dae403ade8745751ac8f7b36e070"}
+rsatoolbox = "0.0.4"
 hydra-core = "^1.1"
 hydra-colorlog = "^1.1"
 matplotlib = "^3.5"


### PR DESCRIPTION
We did not use rsatoolbox fit_regress_nn, so we do not need to pin to the Git revision.

This reverts commit 69ddf7680ab071c00af9dd7d1eb1b82fe15e59c4.